### PR TITLE
Hotfix 0.1.5

### DIFF
--- a/lib/duracloud/rest_methods.rb
+++ b/lib/duracloud/rest_methods.rb
@@ -91,7 +91,8 @@ module Duracloud
     end
 
     def durastore_content(http_method, space_id, content_id, **options)
-      url = [ space_id, content_id ].join("/")
+      escaped_content_id = content_id.gsub(/%/, "%25")
+      url = [ space_id, escaped_content_id ].join("/")
       durastore(http_method, url, **options)
     end
 

--- a/lib/duracloud/version.rb
+++ b/lib/duracloud/version.rb
@@ -1,3 +1,3 @@
 module Duracloud
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -111,6 +111,11 @@ module Duracloud
         subject.get_content("foo", "bar")
         expect(stub).to have_been_requested
       }
+      it "escapes percent signs in the content id" do
+        stub = stub_request(:get, "https://example.com/durastore/foo/z/z/bar%252Fbaz")
+        subject.get_content("foo", "z/z/bar%2Fbaz")
+        expect(stub).to have_been_requested
+      end
       specify {
         stub = stub_request(:get, "https://example.com/durastore/foo/bar")
                .with(query: {storeID: 1})
@@ -125,6 +130,11 @@ module Duracloud
         subject.get_content_properties("foo", "bar")
         expect(stub).to have_been_requested
       }
+      it "escapes percent signs in the content id" do
+        stub = stub_request(:head, "https://example.com/durastore/foo/z/z/bar%252Fbaz")
+        subject.get_content_properties("foo", "z/z/bar%2Fbaz")
+        expect(stub).to have_been_requested
+      end
       specify {
         stub = stub_request(:head, "https://example.com/durastore/foo/bar")
                .with(query: {storeID: 1})
@@ -141,6 +151,13 @@ module Duracloud
                                        headers: {'x-dura-meta-owner'=>'testuser'})
         expect(stub).to have_been_requested
       }
+      it "escapes percent signs in the content id" do
+        stub = stub_request(:post, "https://example.com/durastore/foo/z/z/bar%252Fbaz")
+               .with(headers: {'x-dura-meta-owner'=>'testuser'})
+        subject.set_content_properties("foo", "z/z/bar%2Fbaz",
+                                       headers: {'x-dura-meta-owner'=>'testuser'})
+        expect(stub).to have_been_requested
+      end
       specify {
         stub = stub_request(:post, "https://example.com/durastore/foo/bar")
                .with(headers: {'x-dura-meta-owner'=>'testuser'},
@@ -168,6 +185,21 @@ module Duracloud
                               })
         expect(stub).to have_been_requested
       }
+      it "escapes percent signs in the content id" do
+        stub = stub_request(:put, "https://example.com/durastore/foo/z/z/bar%252Fbaz")
+               .with(body: "File content",
+                     headers: {
+                       'Content-Type'=>'text/plain',
+                       'Content-MD5'=>'8bb2564936980e92ceec8a5759ec34a8'
+                     })
+        subject.store_content("foo", "z/z/bar%2Fbaz",
+                              body: "File content",
+                              headers: {
+                                'Content-Type'=>'text/plain',
+                                'Content-MD5'=>'8bb2564936980e92ceec8a5759ec34a8'
+                              })
+        expect(stub).to have_been_requested
+      end
       specify {
         stub = stub_request(:put, "https://example.com/durastore/foo/bar")
                .with(body: "File content",
@@ -193,6 +225,11 @@ module Duracloud
         subject.delete_content("foo", "bar")
         expect(stub).to have_been_requested
       }
+      it "escapes percent signs in the content id" do
+        stub = stub_request(:delete, "https://example.com/durastore/foo/z/z/bar%252Fbaz")
+        subject.delete_content("foo", "z/z/bar%2Fbaz")
+        expect(stub).to have_been_requested
+      end
       specify {
         stub = stub_request(:delete, "https://example.com/durastore/foo/bar")
                .with(query: {storeID: 1})


### PR DESCRIPTION
URL-escapes percent signs in content id (fixes #11).
