### PR TITLE
API CHANGE: `Duracloud::Content` implements `ActiveModel::Model`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 rvm:
-  - 2.1
   - 2.2
-  - 2.3.0
+  - 2.3.1
 gemfile:
-  - gemfiles/Gemfile.activemodel-4.1
   - gemfiles/Gemfile.activemodel-4.2

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source 'https://rubygems.org'
+ruby '2.3.1'
 
 # Specify your gem's dependencies in duracloud.gemspec
 gemspec
+
+gem 'activemodel', '~> 4.2.7'

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ foo8
 #### Create a new content item and store it in DuraCloud
 
 ```
->> new_content = Duracloud::Content.new("rest-api-testing", "ark:/99999/fk4zzzz")
+>> new_content = Duracloud::Content.new(space_id: "rest-api-testing", content_id: "ark:/99999/fk4zzzz")
  => #<Duracloud::Content space_id="rest-api-testing", content_id="ark:/99999/fk4zzzz", store_id=(default)>
  
 >> new_content.body = "test"
@@ -138,16 +138,20 @@ foo8
  => #<Duracloud::Content space_id="rest-api-testing", content_id="ark:/99999/fk4zzzz", store_id=(default)>
 ```
 
-When storing content a `Duracloud::NotFoundError` is raised if the space does not exist. A `Duracloud::BadRequestError` is raised if the content ID is invalid.
+When storing content a `Duracloud::NotFoundError` is raised if the space does not exist.
+A `Duracloud::BadRequestError` is raised if the content ID is invalid.
+A `Duracloud::ConflictError` is raised if the provided MD5 digest does not match the stored digest.
 
 #### Retrieve an existing content item from DuraCloud
 
 ```
->> Duracloud::Content.find("spaceID", "contentID")
+>> Duracloud::Content.find(space_id: "spaceID", content_id: "contentID")
  => #<Duracloud::Content space_id="spaceID", content_id="contentID", store_id=(default)>
 ```
 
 If the space or content ID does not exist, a `Duracloud::NotFoundError` is raised.
+If an MD5 digest is provided (:md5 attribute), a `Duracloud::MessageDigestError` is
+raised if the content ID exists and the stored digest does not match.
 
 #### Update the properties for a content item
 

--- a/duracloud.gemspec
+++ b/duracloud.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "hashie", "~> 3.4"
   spec.add_dependency "httpclient", "~> 2.7"
-  spec.add_dependency "activemodel", "~> 4.1"
+  spec.add_dependency "activemodel", ">= 4.2", "< 6"
   spec.add_dependency "nokogiri", "~> 1.6"
 
   spec.add_development_dependency "webmock", "~> 2.0"

--- a/gemfiles/Gemfile.activemodel-4.1
+++ b/gemfiles/Gemfile.activemodel-4.1
@@ -1,3 +1,0 @@
-source 'https://rubygems.org'
-gem "activemodel", "~> 4.1.16"
-gemspec path: "../"

--- a/lib/duracloud/error.rb
+++ b/lib/duracloud/error.rb
@@ -4,4 +4,5 @@ module Duracloud
   class NotFoundError < Error; end
   class BadRequestError < Error; end
   class ConflictError < Error; end
+  class MessageDigestError < Error; end
 end

--- a/lib/duracloud/space.rb
+++ b/lib/duracloud/space.rb
@@ -160,7 +160,7 @@ module Duracloud
     # @return [Duracloud::Content] the content item.
     # @raise [Duracloud::NotFoundError] if the content item does not exist.
     def find_content(content_id)
-      Content.find(space_id, content_id, store_id)
+      Content.find(space_id: space_id, content_id: content_id, store_id: store_id)
     end
 
     # Return the audit log for the space


### PR DESCRIPTION
- Initialization of `Duracloud::Content` has changed to use a hash
of attributes, rather than positional arguments.
- Setting MD5 digest in initialization is supported (closes #7, closes #10).
If set, digest is used to validate GET and HEAD responses.