### PR TITLE
Release 0.3.0

### DIFF
--- a/lib/duracloud/content.rb
+++ b/lib/duracloud/content.rb
@@ -107,11 +107,22 @@ module Duracloud
       @md5
     end
 
+    # @return [Duracloud::Content] the copied content
+    #   The current instance still represents the original content.
     def copy(target_space_id:, target_content_id:, target_store_id: nil)
       copy_headers = {'x-dura-meta-copy-source'=>[space_id, content_id].join('/')}
       copy_headers['x-dura-meta-copy-source-store'] = store_id if store_id
       options = { storeID: target_store_id, headers: copy_headers }
       Client.copy_content(target_space_id, target_content_id, **options)
+      Content.find(space_id: target_space_id, content_id: target_content_id, store_id: target_store_id, md5: md5)
+    end
+
+    # @return [Duracloud::Content] the moved content
+    #   The current instance still represents the deleted content.
+    def move(**args)
+      copied = copy(**args)
+      delete
+      copied
     end
 
     private

--- a/lib/duracloud/version.rb
+++ b/lib/duracloud/version.rb
@@ -1,3 +1,3 @@
 module Duracloud
-  VERSION = "0.3.0.pre"
+  VERSION = "0.3.0"
 end

--- a/spec/unit/content_spec.rb
+++ b/spec/unit/content_spec.rb
@@ -173,12 +173,32 @@ module Duracloud
     end
 
     describe "#copy" do
+      let(:target) { "https://example.com/durastore/spam/eggs" }
       subject { Content.new(space_id: "foo", content_id: "bar") }
       specify {
-        stub = stub_request(:put, "https://example.com/durastore/spam/eggs")
-          .with(headers: {'x-dura-meta-copy-source'=>'foo/bar'})
-        subject.copy(target_space_id: "spam", target_content_id: "eggs")
-        expect(stub).to have_been_requested
+        stub1 = stub_request(:put, target)
+                .with(headers: {'x-dura-meta-copy-source'=>'foo/bar'})
+        stub2 = stub_request(:head, target)
+        copied = subject.copy(target_space_id: "spam", target_content_id: "eggs")
+        expect(copied).to be_a(Content)
+        expect(stub1).to have_been_requested
+        expect(stub2).to have_been_requested
+      }
+    end
+
+    describe "#move" do
+      let(:target) { "https://example.com/durastore/spam/eggs" }
+      subject { Content.new(space_id: "foo", content_id: "bar") }
+      specify {
+        stub1 = stub_request(:put, target)
+                .with(headers: {'x-dura-meta-copy-source'=>'foo/bar'})
+        stub2 = stub_request(:head, target)
+        stub3 = stub_request(:delete, "https://example.com/durastore/foo/bar")
+        moved = subject.move(target_space_id: "spam", target_content_id: "eggs")
+        expect(moved).to be_a(Content)
+        expect(stub1).to have_been_requested
+        expect(stub2).to have_been_requested
+        expect(stub3).to have_been_requested
       }
     end
 


### PR DESCRIPTION
Added `Duracloud::Content#move` to support copy and delete.
Closes #17.