### PR TITLE
Implements storage report APIs (closes #31).

### DIFF
--- a/lib/duracloud.rb
+++ b/lib/duracloud.rb
@@ -24,6 +24,8 @@ module Duracloud
   autoload :Space, "duracloud/space"
   autoload :SpaceAcls, "duracloud/space_acls"
   autoload :Store, "duracloud/store"
+  autoload :StorageReport, "duracloud/storage_report"
+  autoload :StorageReports, "duracloud/storage_reports"
   autoload :SyncValidation, "duracloud/sync_validation"
   autoload :TSV, "duracloud/tsv"
 end

--- a/lib/duracloud/commands/get_storage_report.rb
+++ b/lib/duracloud/commands/get_storage_report.rb
@@ -1,0 +1,17 @@
+require_relative "command"
+
+module Duracloud::Commands
+  class GetStorageReport < Command
+
+    def call
+      reports = if space_id
+                  Duracloud::StorageReports.by_space(space_id, store_id: store_id)
+                else
+                  Duracloud::StorageReports.by_store(store_id: store_id)
+                end
+      report = reports.last
+      puts report.to_s
+    end
+
+  end
+end

--- a/lib/duracloud/rest_methods.rb
+++ b/lib/duracloud/rest_methods.rb
@@ -108,6 +108,21 @@ module Duracloud
             "The API method 'Perform Task' has not been implemented."
     end
 
+    # @see https://wiki.duraspace.org/display/DURACLOUDDOC/DuraCloud+REST+API#DuraCloudRESTAPI-GetStorageReportsbySpace
+    def get_storage_reports_by_space(space_id, **query)
+      durastore(:get, "report/space/#{space_id}", **query)
+    end
+
+    # @see https://wiki.duraspace.org/display/DURACLOUDDOC/DuraCloud+REST+API#DuraCloudRESTAPI-GetStorageReportsbyStore
+    def get_storage_reports_by_store(**query)
+      durastore(:get, "report/store", **query)
+    end
+
+    # @see https://wiki.duraspace.org/display/DURACLOUDDOC/DuraCloud+REST+API#DuraCloudRESTAPI-GetStorageReportsforallSpacesinaStore(inasingleday)
+    def get_storage_reports_for_all_spaces_in_a_store(epoch_ms, **query)
+      durastore(:get, "report/store/#{epoch_ms}", **query)
+    end
+
     private
 
     def durastore(*args, &block)

--- a/lib/duracloud/storage_report.rb
+++ b/lib/duracloud/storage_report.rb
@@ -1,0 +1,33 @@
+require 'hashie'
+require 'active_support'
+
+module Duracloud
+  class StorageReport < Hashie::Trash
+
+    property "space_id",     from: "spaceId"
+    property "store_id",     from: "storeId"
+    property "byte_count",   from: "byteCount"
+    property "object_count", from: "objectCount"
+    property "account_id",   from: "accountId"
+    property "timestamp"
+
+    def time
+      @time ||= Time.at(timestamp / 1000.0).utc
+    end
+
+    def human_size
+      ActiveSupport::NumberHelper.number_to_human_size(byte_count, prefix: :si)
+    end
+
+    def to_s
+      <<-EOS
+Date:       #{time}
+Space ID:   #{space_id || "(all)"}
+Store ID:   #{store_id}
+Objects:    #{object_count}
+Total size: #{human_size} (#{byte_count} bytes)
+      EOS
+    end
+
+  end
+end

--- a/lib/duracloud/storage_reports.rb
+++ b/lib/duracloud/storage_reports.rb
@@ -1,0 +1,52 @@
+require 'json'
+require 'hashie'
+
+module Duracloud
+  class StorageReports
+    include Enumerable
+    extend Forwardable
+
+    delegate :last => :to_a
+
+    attr_reader :data
+
+    def self.by_space(space_id, **query)
+      params = Params.new(query)
+      response = Client.get_storage_reports_by_space(space_id, **params)
+      new(response)
+    end
+
+    def self.by_store(**query)
+      params = Params.new(query)
+      response = Client.get_storage_reports_by_store(**params)
+      new(response)
+    end
+
+    def self.for_all_spaces_in_a_store(epoch_ms = nil, **query)
+      epoch_ms ||= Time.now.to_i * 1000
+      params = Params.new(query)
+      response = Client.get_storage_reports_for_all_spaces_in_a_store(epoch_ms, **params)
+      new(response)
+    end
+
+    def initialize(response)
+      @data = JSON.parse(response.body)
+    end
+
+    def each
+      data.each do |report|
+        yield StorageReport.new(report)
+      end
+    end
+
+    private
+
+    class Params < Hashie::Trash
+      property :storeID, from: :store_id
+      property :groupBy, from: :group_by
+      property :start
+      property :end
+    end
+
+  end
+end

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -4,38 +4,42 @@ module Duracloud
     subject { described_class.new(**opts) }
 
     describe "properties" do
-      let(:opts) { {space_id: "foo", content_id: "bar"} }
-      let(:command) { "properties" }
+      let(:opts) { {command: "properties", space_id: "foo", content_id: "bar"} }
       specify {
         expect(Commands::GetProperties).to receive(:call).with(subject) { nil }
-        subject.execute(command)
+        subject.execute
       }
     end
 
     describe "sync" do
-      let(:opts) { {space_id: "foo", content_id: "bar", infile: "foo/bar"} }
-      let(:command) { "sync" }
+      let(:opts) { {command: "sync", space_id: "foo", content_id: "bar", infile: "foo/bar"} }
       specify {
         expect(Commands::Sync).to receive(:call).with(subject) { nil }
-        subject.execute(command)
+        subject.execute
       }
     end
 
     describe "validate" do
-      let(:opts) { {space_id: "foo", content_dir: "/tmp"} }
-      let(:command) { "validate" }
+      let(:opts) { {command: "validate", space_id: "foo", content_dir: "/tmp"} }
       specify {
         expect(Commands::Validate).to receive(:call).with(subject) { nil }
-        subject.execute(command)
+        subject.execute
       }
     end
 
     describe "manifest" do
-      let(:opts) { {space_id: "foo"} }
-      let(:command) { "manifest" }
+      let(:opts) { {command: "manifest", space_id: "foo"} }
       specify {
         expect(Commands::DownloadManifest).to receive(:call).with(subject) { nil }
-        subject.execute(command)
+        subject.execute
+      }
+    end
+
+    describe "storage" do
+      let(:opts) { {command: "storage", space_id: "foo"} }
+      specify {
+        expect(Commands::GetStorageReport).to receive(:call).with(subject) { nil }
+        subject.execute
       }
     end
 

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -329,5 +329,29 @@ module Duracloud
           .to raise_error(NotImplementedError)
       }
     end
+
+    describe "get_storage_reports_by_space" do
+      specify {
+        stub = stub_request(:get, "https://example.com/durastore/report/space/foo")
+        subject.get_storage_reports_by_space("foo")
+        expect(stub).to have_been_requested
+      }
+    end
+
+    describe "get_storage_reports_by_store" do
+      specify {
+        stub = stub_request(:get, "https://example.com/durastore/report/store")
+        subject.get_storage_reports_by_store
+        expect(stub).to have_been_requested
+      }
+    end
+
+    describe "get_storage_reports_for_all_spaces_in_a_store" do
+      specify {
+        stub = stub_request(:get, "https://example.com/durastore/report/store/1499400000000")
+        subject.get_storage_reports_for_all_spaces_in_a_store(1499400000000)
+        expect(stub).to have_been_requested
+      }
+    end
   end
 end

--- a/spec/unit/storage_report_spec.rb
+++ b/spec/unit/storage_report_spec.rb
@@ -1,0 +1,15 @@
+module Duracloud
+  RSpec.describe StorageReport do
+
+    subject { described_class.new("timestamp"=>1312588800000,"accountId"=>"account1","spaceId"=>"space1","storeId"=>"store1","byteCount"=>1000,"objectCount"=>10) }
+
+    its(:space_id) { is_expected.to eq "space1" }
+    its(:store_id) { is_expected.to eq "store1" }
+    its(:account_id) { is_expected.to eq "account1" }
+    its(:byte_count) { is_expected.to eq 1000 }
+    its(:object_count) { is_expected.to eq 10 }
+    its(:timestamp) { is_expected.to eq 1312588800000 }
+    its(:time) { is_expected.to eq Time.at(1312588800000 / 1000.0) }
+
+  end
+end

--- a/spec/unit/storage_reports_spec.rb
+++ b/spec/unit/storage_reports_spec.rb
@@ -1,0 +1,45 @@
+module Duracloud
+  RSpec.describe StorageReports do
+
+    describe ".by_space" do
+      subject { described_class.by_space("foo") }
+      specify {
+        stub_request(:get, "https://example.com/durastore/report/space/foo")
+          .to_return(body: '[
+  {"timestamp":1312588800000,"accountId":"<account-id>","spaceId":"<space-id>","storeId":"<store-id>","byteCount":1000,"objectCount":10},
+  {"timestamp":1315008000000,"accountId":"<account-id>","spaceId":"<space-id>","storeId":"<store-id>","byteCount":1000,"objectCount":10},
+  {"timestamp":1315526400000,"accountId":"<account-id>","spaceId":"<space-id>","storeId":"<store-id>","byteCount":1000,"objectCount":10}
+]')
+        expect(subject.map(&:timestamp)).to eq [ 1312588800000, 1315008000000, 1315526400000 ]
+      }
+    end
+
+    describe ".by_store" do
+      subject { described_class.by_store }
+      specify {
+        stub_request(:get, "https://example.com/durastore/report/store")
+          .to_return(body: '[
+  {"timestamp":1312588800000,"accountId":"<account-id>","storeId":"<store-id>","byteCount":1000,"objectCount":10},
+  {"timestamp":1315008000000,"accountId":"<account-id>","storeId":"<store-id>","byteCount":1000,"objectCount":10},
+  {"timestamp":1315526400000,"accountId":"<account-id>","storeId":"<store-id>","byteCount":1000,"objectCount":10}
+]')
+        expect(subject.map(&:timestamp)).to eq [ 1312588800000, 1315008000000, 1315526400000 ]
+      }
+    end
+
+    describe ".for_all_spaces_in_a_store" do
+      subject { described_class.for_all_spaces_in_a_store(1499400000000) }
+      specify {
+        stub_request(:get, "https://example.com/durastore/report/store/1499400000000")
+          .to_return(body: '[
+  {"timestamp":1312588800000,"accountId":"<account-id>","spaceId":"<space-id-1>","storeId":"<store-id>","byteCount":1000,"objectCount":10},
+  {"timestamp":1315008000000,"accountId":"<account-id>","spaceId":"<space-id-2>","storeId":"<store-id>","byteCount":1000,"objectCount":10},
+  {"timestamp":1315526400000,"accountId":"<account-id>","spaceId":"<space-id-3>","storeId":"<store-id>","byteCount":1000,"objectCount":10}
+]')
+        expect(subject.map(&:timestamp)).to eq [ 1312588800000, 1315008000000, 1315526400000 ]
+      }
+    end
+
+
+  end
+end


### PR DESCRIPTION
Adds `storage` command to bin/duracloud. This command gets the
latest report by space (if space_id is given) or store (otherwise)
and prints to stdout.