### PR TITLE
SyncValidation refactored to accept a work_dir in which to write files.

### DIFF
--- a/lib/duracloud/cli.rb
+++ b/lib/duracloud/cli.rb
@@ -20,7 +20,7 @@ EOS
     attr_accessor :command, :user, :password, :host, :port,
                   :space_id, :store_id, :content_id,
                   :content_type, :md5,
-                  :content_dir, :format, :infile,
+                  :content_dir, :format, :infile, :work_dir,
                   :logging
 
     validates_presence_of :space_id, message: "-s/--space-id option is required.", unless: "command == 'storage'"
@@ -101,7 +101,7 @@ EOS
           options[:format] = Manifest::BAGIT_FORMAT
         end
 
-        opts.on("-d", "--content-dir CONTENT_DIR",
+        opts.on("-d", "--content-dir DIR",
                 "Local content directory") do |v|
           options[:content_dir] = v
         end
@@ -115,6 +115,11 @@ EOS
                 "Print version and exit") do |v|
           print_version
           exit
+        end
+
+        opts.on("-w", "--work-dir DIR",
+                "Working directory") do |v|
+          options[:work_dir] = v
         end
       end
 

--- a/lib/duracloud/commands/command.rb
+++ b/lib/duracloud/commands/command.rb
@@ -3,8 +3,8 @@ require 'delegate'
 module Duracloud::Commands
   class Command < SimpleDelegator
 
-    def self.call(command)
-      new(command).call
+    def self.call(cli)
+      new(cli).call
     end
 
   end

--- a/lib/duracloud/commands/validate.rb
+++ b/lib/duracloud/commands/validate.rb
@@ -4,7 +4,7 @@ module Duracloud::Commands
   class Validate < Command
 
     def call
-      Duracloud::SyncValidation.call(space_id: space_id, store_id: store_id, content_dir: content_dir)
+      Duracloud::SyncValidation.call(space_id: space_id, store_id: store_id, content_dir: content_dir, work_dir: work_dir)
     end
 
   end

--- a/lib/duracloud/sync_validation.rb
+++ b/lib/duracloud/sync_validation.rb
@@ -1,6 +1,7 @@
 require 'active_model'
 require 'tempfile'
 require 'csv'
+require 'fileutils'
 
 module Duracloud
   class SyncValidation
@@ -10,56 +11,98 @@ module Duracloud
     MD5_CSV_OPTS = { col_sep: TWO_SPACES }.freeze
     MANIFEST_CSV_OPTS = { col_sep: "\t", headers: true, return_headers: false }.freeze
 
-    attr_accessor :space_id, :content_dir, :store_id
+    MISSING = "MISSING"
+    CHANGED = "CHANGED"
+    FOUND   = "FOUND"
+
+    attr_accessor :space_id, :content_dir, :store_id, :work_dir
 
     def self.call(*args)
       new(*args).call
     end
 
+    def in_work_dir
+      if work_dir
+        FileUtils.cd(work_dir) { yield }
+      else
+        Dir.mktmpdir("#{space_id}-validation-") do |tmpdir|
+          FileUtils.cd(tmpdir) { yield }
+        end
+      end
+    end
+
     def call
-      Tempfile.open("#{space_id}-manifest") do |manifest|
+      in_work_dir do
+        download_manifest
+        convert_manifest
+        audit
+      end
+    end
+
+    def download_manifest
+      File.open(manifest_filename, "w") do |manifest|
         Manifest.download(space_id, store_id) do |chunk|
           manifest.write(chunk)
         end
-        manifest.close
+      end
+    end
 
-        # convert manifest into md5deep format
-        Tempfile.open("#{space_id}-md5") do |md5_list|
-          CSV.foreach(manifest.path, MANIFEST_CSV_OPTS) do |row|
-            md5_list.puts [ row[2], row[1] ].join(TWO_SPACES)
-          end
-          md5_list.close
-
-          # run md5deep to find files not listed in the manifest
-          Tempfile.open("#{space_id}-audit") do |audit|
-            audit.close
-            pid = spawn("md5deep", "-X", md5_list.path, "-l", "-r", ".", chdir: content_dir, out: audit.path)
-            Process.wait(pid)
-            case $?.exitstatus
-            when 0
-              true
-            when 1, 2
-              failures = []
-              CSV.foreach(audit.path, MD5_CSV_OPTS) do |md5, path|
-                content_id = path.sub(/^\.\//, "")
-                begin
-                  if !Duracloud::Content.exist?(space_id: space_id, store_id: store_id, content_id: content_id, md5: md5)
-                    failures << [ "MISSING", md5, content_id ].join("\t")
-                  end
-                rescue MessageDigestError => e
-                  failures << [ "CHANGED", md5, content_id ].join("\t")
-                end
-              end
-              STDOUT.puts failures
-              failures.empty?
-            when 64
-              raise Error, "md5deep user error."
-            when 128
-              raise Error, "md5deep internal error."
-            end
-          end
+    def convert_manifest
+      File.open(md5_filename, "w") do |f|
+        CSV.foreach(manifest_filename, MANIFEST_CSV_OPTS) do |row|
+          f.puts [ row[2], row[1] ].join(TWO_SPACES)
         end
       end
+    end
+
+    def audit
+      outfile = File.join(FileUtils.pwd, audit_filename)
+      infile = File.join(FileUtils.pwd, md5_filename)
+      pid = spawn("md5deep", "-X", infile, "-l", "-r", ".", chdir: content_dir, out: outfile)
+      Process.wait(pid)
+      case $?.exitstatus
+      when 0
+        true
+      when 1, 2
+        recheck_failures
+      when 64, 128
+        raise Error, "md5deep error."
+      else
+        raise Error, "Unknown error."
+      end
+    end
+
+    def recheck_failures
+      success = true
+      CSV($stdout, col_sep: "\t") do |output|
+        CSV.foreach(audit_filename, MD5_CSV_OPTS) do |md5, path|
+          content_id = path.sub(/^\.\//, "")
+          status = begin
+                     if Duracloud::Content.exist?(space_id: space_id, store_id: store_id, content_id: content_id, md5: md5)
+                       FOUND
+                     else
+                       MISSING
+                     end
+                   rescue MessageDigestError => e
+                     CHANGED
+                   end
+          output << [ status, md5, content_id ]
+          success &&= ( status == FOUND )
+        end
+      end
+      success
+    end
+
+    def manifest_filename
+      "#{space_id}-manifest.tsv"
+    end
+
+    def md5_filename
+      "#{space_id}-md5.txt"
+    end
+
+    def audit_filename
+      "#{space_id}-audit.txt"
     end
 
   end


### PR DESCRIPTION
The default behavior is to write to a temp directory which is removed
on completion of the process. If a work_dir is provided, the files
are not removed on completion.

Added -w/--work-dir option to CLI.