### PR TITLE
Adds `Duracloud::FastSyncValidation`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,24 @@ Assumptions:
 Process:
 - The space manifest is downloaded from DuraCloud and converted to the expected input format for `md5deep` (two columns: md5 hash and file path, separated by two spaces).
 - `md5deep` is run against the content directory in "non-matching" mode (-X) with the converted manifest as the list of "known hashes".
-- Non-matching files from the `md5deep` run are re-checked individually by calling `Duracloud::Content.exist?`. This pass will account for content sync after `md5deep` started as well as files that have been chunked in DuraCloud.
+- Non-matching files from the `md5deep` run are re-checked individually by calling `Duracloud::Content.exist?`.
+This pass will account for content sync after `md5deep` started as well as files that have been chunked in DuraCloud.
+Results of this re-check are printed to STDOUT (or, if using the `:work_dir` option, below, to a file).
 
 ```ruby
 Duracloud::SyncValidation.call(space_id: 'foo', content_dir: '/var/foo/bar')
 ```
+
+*Added in version 0.9.0* - `:work_dir` option to specify existing directory in which to write validation files. The default behavior is to
+create a temporary directory which is deleted on completion of the process. If `:work_dir` is specified, no cleanup is performed.
+
+Files created in work directory:
+- `{SPACE_ID}-manifest.tsv` (DuraCloud manifest as downloaded)
+- `{SPACE_ID}-md5.txt` (Munged manifest for md5deep)
+- `{SPACE_ID}-audit.txt` (Output of md5deep, empty if all files match)
+- `{SPACE_ID}-recheck.txt` (Out of audit recheck, if necessary)
+
+*Added in version 0.9.0* - `Duracloud::FastSyncValidation`. This variant of sync validation does not compute local hashes but instead compares the local file list (generated with `find`) to the list of content IDs in the space manifest. Local misses are rechecked as in `SyncValidation` (but without MD5 comparison).
 
 ### Content
 

--- a/lib/duracloud.rb
+++ b/lib/duracloud.rb
@@ -14,6 +14,7 @@ module Duracloud
   autoload :ContentManifest, "duracloud/content_manifest"
   autoload :DurastoreRequest, "duracloud/durastore_request"
   autoload :ErrorHandler, "duracloud/error_handler"
+  autoload :FastSyncValidation, "duracloud/fast_sync_validation"
   autoload :HasProperties, "duracloud/has_properties"
   autoload :Manifest, "duracloud/manifest"
   autoload :Persistence, "duracloud/persistence"

--- a/lib/duracloud/cli.rb
+++ b/lib/duracloud/cli.rb
@@ -20,7 +20,7 @@ EOS
     attr_accessor :command, :user, :password, :host, :port,
                   :space_id, :store_id, :content_id,
                   :content_type, :md5,
-                  :content_dir, :format, :infile, :work_dir,
+                  :content_dir, :format, :infile, :work_dir, :fast,
                   :logging
 
     validates_presence_of :space_id, message: "-s/--space-id option is required.", unless: "command == 'storage'"
@@ -120,6 +120,11 @@ EOS
         opts.on("-w", "--work-dir DIR",
                 "Working directory") do |v|
           options[:work_dir] = v
+        end
+
+        opts.on("-F", "--[no-]fast",
+                "Use fast audit for sync validation") do |v|
+          options[:fast] = v
         end
       end
 

--- a/lib/duracloud/commands/validate.rb
+++ b/lib/duracloud/commands/validate.rb
@@ -4,7 +4,8 @@ module Duracloud::Commands
   class Validate < Command
 
     def call
-      Duracloud::SyncValidation.call(space_id: space_id, store_id: store_id, content_dir: content_dir, work_dir: work_dir)
+      klass = fast ? Duracloud::FastSyncValidation : DuracloudSyncValidation
+      klass.call(space_id: space_id, store_id: store_id, content_dir: content_dir, work_dir: work_dir)
     end
 
   end

--- a/lib/duracloud/fast_sync_validation.rb
+++ b/lib/duracloud/fast_sync_validation.rb
@@ -1,0 +1,42 @@
+module Duracloud
+  class FastSyncValidation < SyncValidation
+
+    def convert_manifest
+      # content-id is the 2nd column of the manifest
+      system("cut -f 2 #{manifest_filename} | sort", out: converted_manifest_filename)
+    end
+
+    def audit
+      find_files
+      if system("comm", "-23", find_filename, converted_manifest_filename, out: audit_filename)
+        File.empty?(audit_filename) || recheck
+      else
+        raise Error, "Error comparing #{find_filename} with #{converted_manifest_filename}."
+      end
+    end
+
+    def find_files
+      # TODO handle exclude file?
+      outfile = File.join(FileUtils.pwd, find_filename)
+      # Using a separate command for sort so we get find results incrementally
+      system("find -L . -type f | sed -e 's|^\./||'", chdir: content_dir, out: outfile) &&
+        system("sort", "-o", find_filename, find_filename)
+    end
+
+    private
+
+    def do_recheck
+      Enumerator.new do |e|
+        File.foreach(audit_filename) do |line|
+          content_id = line.chomp
+          e << check(content_id)
+        end
+      end
+    end
+
+    def find_filename
+      filename("find.txt")
+    end
+
+  end
+end

--- a/lib/duracloud/sync_validation.rb
+++ b/lib/duracloud/sync_validation.rb
@@ -15,7 +15,7 @@ module Duracloud
     CHANGED = "CHANGED"
     FOUND   = "FOUND"
 
-    attr_accessor :space_id, :content_dir, :store_id, :work_dir
+    attr_accessor :space_id, :content_dir, :store_id, :work_dir, :fast
 
     def self.call(*args)
       new(*args).call
@@ -48,7 +48,7 @@ module Duracloud
     end
 
     def convert_manifest
-      File.open(md5_filename, "w") do |f|
+      File.open(converted_manifest_filename, "w") do |f|
         CSV.foreach(manifest_filename, MANIFEST_CSV_OPTS) do |row|
           f.puts [ row[2], row[1] ].join(TWO_SPACES)
         end
@@ -57,14 +57,14 @@ module Duracloud
 
     def audit
       outfile = File.join(FileUtils.pwd, audit_filename)
-      infile = File.join(FileUtils.pwd, md5_filename)
+      infile = File.join(FileUtils.pwd, converted_manifest_filename)
       pid = spawn("md5deep", "-X", infile, "-l", "-r", ".", chdir: content_dir, out: outfile)
       Process.wait(pid)
       case $?.exitstatus
       when 0
         true
       when 1, 2
-        recheck_failures
+        recheck
       when 64, 128
         raise Error, "md5deep error."
       else
@@ -72,37 +72,77 @@ module Duracloud
       end
     end
 
-    def recheck_failures
+    def recheck
       success = true
-      CSV($stdout, col_sep: "\t") do |output|
-        CSV.foreach(audit_filename, MD5_CSV_OPTS) do |md5, path|
-          content_id = path.sub(/^\.\//, "")
-          status = begin
-                     if Duracloud::Content.exist?(space_id: space_id, store_id: store_id, content_id: content_id, md5: md5)
-                       FOUND
-                     else
-                       MISSING
-                     end
-                   rescue MessageDigestError => e
-                     CHANGED
-                   end
-          output << [ status, md5, content_id ]
-          success &&= ( status == FOUND )
+      recheck_file do |csv|
+        do_recheck.each do |result|
+          csv << result.to_a
+          success &&= result.found?
         end
       end
       success
     end
 
-    def manifest_filename
-      "#{space_id}-manifest.tsv"
+    private
+
+    CheckResult = Struct.new(:status, :md5, :content_id) do
+      def found?
+        status == FOUND
+      end
     end
 
-    def md5_filename
-      "#{space_id}-md5.txt"
+    def recheck_file
+      if work_dir
+        CSV.open(recheck_filename, "w", col_sep: "\t") { |csv| yield(csv) }
+      else
+        CSV($stdout, col_sep: "\t") { |csv| yield(csv) }
+      end
+    end
+
+    def check(content_id, md5 = nil)
+      status = begin
+                 exist?(content_id, md5) ? FOUND : MISSING
+               rescue MessageDigestError => e
+                 CHANGED
+               end
+      CheckResult.new(status, md5 || "-", content_id)
+    end
+
+    def exist?(content_id, md5 = nil)
+      Duracloud::Content.exist?(space_id: space_id, store_id: store_id, content_id: content_id, md5: md5)
+    end
+
+    def do_recheck
+      Enumerator.new do |e|
+        CSV.foreach(audit_filename, MD5_CSV_OPTS) do |md5, path|
+          content_id = path.sub(/^\.\//, "")
+          e << check(content_id, md5)
+        end
+      end
+    end
+
+    def prefix
+      space_id
+    end
+
+    def filename(suffix)
+      [ prefix, suffix ].join("-")
+    end
+
+    def manifest_filename
+      filename("manifest.tsv")
+    end
+
+    def converted_manifest_filename
+      filename("converted-manifest.txt")
     end
 
     def audit_filename
-      "#{space_id}-audit.txt"
+      filename("audit.txt")
+    end
+
+    def recheck_filename
+      filename("recheck.txt")
     end
 
   end


### PR DESCRIPTION
Fast validation only compares the local list of relative file paths
to the list of content IDs from the DuraCloud space. MD5 checksums
are not compared (md5deep is not used). The rechecking phase is the same,
albeit without MD5 verification.