### PR TITLE
Hotfix 0.9.1

### DIFF
--- a/duracloud.gemspec
+++ b/duracloud.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.2"
 
+  spec.add_dependency "addressable", "~> 2.5"
   spec.add_dependency "hashie", "~> 3.4"
   spec.add_dependency "httpclient", "~> 2.7"
   spec.add_dependency "activemodel", ">= 4.2", "< 6"

--- a/lib/duracloud/request.rb
+++ b/lib/duracloud/request.rb
@@ -1,3 +1,5 @@
+require 'addressable/uri'
+
 module Duracloud
   class Request
     attr_reader :client, :url, :http_method, :body, :headers, :query
@@ -12,7 +14,7 @@ module Duracloud
     def initialize(client, http_method, url, **options)
       @client      = client
       @http_method = http_method
-      @url         = url
+      @url         = Addressable::URI.parse(url).normalize.to_s
       set_options(options.dup)
     end
 

--- a/lib/duracloud/rest_methods.rb
+++ b/lib/duracloud/rest_methods.rb
@@ -130,8 +130,7 @@ module Duracloud
     end
 
     def durastore_content(http_method, space_id, content_id, **options, &block)
-      escaped_content_id = content_id.gsub(/%/, "%25").gsub(/ /, "%20")
-      url = [ space_id, escaped_content_id ].join("/")
+      url = [ space_id, content_id.gsub(/%/, "%25") ].join("/")
       durastore(http_method, url, **options, &block)
     end
 

--- a/lib/duracloud/version.rb
+++ b/lib/duracloud/version.rb
@@ -1,3 +1,3 @@
 module Duracloud
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end


### PR DESCRIPTION
Fixes issue with non-ASCII characters in DuraCloud content ID.
The fix uses Addressable::URI.parse from the `addressable` gem
to normalize the non-ASCII characters properly. As a result,
manual escaping of spaces was removed (but escaping percent signs
in content IDs was retained because they are assumed not to
signify character codes).