### PR TITLE
Removes dependency on activemodel.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: ruby
 rvm:
   - 2.2
   - 2.3.1
-gemfile:
-  - gemfiles/Gemfile.activemodel-4.2
+  - 2.4
+

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'activemodel', '~> 4.2.7'
 gem 'byebug'

--- a/duracloud.gemspec
+++ b/duracloud.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "addressable", "~> 2.5"
   spec.add_dependency "hashie", "~> 3.4"
   spec.add_dependency "httpclient", "~> 2.7"
-  spec.add_dependency "activemodel", ">= 4.2", "< 6"
   spec.add_dependency "nokogiri", "~> 1.6"
 
   spec.add_development_dependency "webmock", "~> 2.0"

--- a/gemfiles/Gemfile.activemodel-4.2
+++ b/gemfiles/Gemfile.activemodel-4.2
@@ -1,3 +1,0 @@
-source 'https://rubygems.org'
-gem "activemodel", "~> 4.2.7"
-gemspec path: "../"

--- a/gemfiles/Gemfile.activemodel-5.0
+++ b/gemfiles/Gemfile.activemodel-5.0
@@ -1,3 +1,0 @@
-source 'https://rubygems.org'
-gem "activemodel", "~> 5.0.1"
-gemspec path: "../"

--- a/lib/duracloud/abstract_entity.rb
+++ b/lib/duracloud/abstract_entity.rb
@@ -1,30 +1,19 @@
-require "active_model"
-
 module Duracloud
-  class AbstractEntity
-    include ActiveModel::Model
-    extend ActiveModel::Callbacks
-
-    define_model_callbacks :save, :delete, :load_properties
-    after_save :persisted!
-    after_save :reset_properties
-    after_load_properties :persisted!
-    before_delete :reset_properties
-    after_delete :deleted!
-    after_delete :freeze
+  class AbstractEntity < Hashie::Dash
 
     def save
       raise Error, "Cannot save deleted #{self.class}." if deleted?
-      run_callbacks :save do
-        do_save
-      end
+      do_save
+      persisted!
+      reset_properties
     end
 
     def delete
       raise Error, "Cannot delete, already deleted." if deleted?
-      run_callbacks :delete do
-        do_delete
-      end
+      reset_properties
+      do_delete
+      deleted!
+      freeze
     end
 
     def persisted?
@@ -46,9 +35,8 @@ module Duracloud
     end
 
     def load_properties
-      run_callbacks :load_properties do
-        do_load_properties
-      end
+      do_load_properties
+      persisted!
     end
 
     private

--- a/lib/duracloud/cli.rb
+++ b/lib/duracloud/cli.rb
@@ -1,9 +1,8 @@
 require 'optparse'
-require 'active_model'
+require 'hashie'
 
 module Duracloud
-  class CLI
-    include ActiveModel::Model
+  class CLI < Hashie::Dash
     include Commands
 
     COMMANDS = Commands.public_instance_methods.map(&:to_s)
@@ -18,32 +17,29 @@ Options:
 EOS
     HELP = "Type 'duracloud -h/--help' for usage."
 
-    attr_accessor :all_spaces,
-                  :command,
-                  :content_dir,
-                  :content_id,
-                  :content_type,
-                  :fast,
-                  :format,
-                  :host,
-                  :infile,
-                  :logging,
-                  :md5,
-                  :missing,
-                  :password,
-                  :port,
-                  :prefix,
-                  :space_id,
-                  :store_id,
-                  :user,
-                  :work_dir
-
-    validates_presence_of :space_id, message: "-s/--space-id option is required.", unless: "command == 'get_storage_report'"
-    validates_inclusion_of :command, in: COMMANDS, message: "Invalid command"
+    property :all_spaces
+    property :command, required: true
+    property :content_dir
+    property :content_id
+    property :content_type
+    property :fast
+    property :format
+    property :host
+    property :infile
+    property :logging
+    property :md5
+    property :missing
+    property :password
+    property :port
+    property :prefix
+    property :space_id, required: -> { command != "get_storage_report" }, message: "-s/--space-id option is required."
+    property :store_id
+    property :user
+    property :work_dir
 
     def self.error!(exception)
       $stderr.puts exception.message
-      if [ CommandError, OptionParser::ParseError ].include?(exception.class)
+      if [ ArgumentError, CommandError, OptionParser::ParseError ].include?(exception.class)
         $stderr.puts HELP
       end
       exit(false)
@@ -56,13 +52,12 @@ EOS
     end
 
     def initialize(*args)
-      super CommandOptions.new(*args)
+      super CommandOptions.parse(*args)
     end
 
     def execute
-      if invalid?
-        message = errors.map { |k, v| "ERROR: #{v}" }.join("\n")
-        raise CommandError, message
+      unless COMMANDS.include?(command)
+        raise CommandError, "Invalid command: #{command.inspect}."
       end
       configure_client
       send(command, self)

--- a/lib/duracloud/command_options.rb
+++ b/lib/duracloud/command_options.rb
@@ -4,10 +4,14 @@ require 'hashie'
 module Duracloud
   class CommandOptions < Hashie::Mash
 
-    def initialize(*args)
-      super()
+    def self.parse(*args)
+      new.parse(*args)
+    end
+
+    def parse(*args)
       self.command = args.shift if CLI::COMMANDS.include?(args.first)
       parser.parse!(args)
+      to_hash(symbolize_keys: true)
     end
 
     def print_version

--- a/lib/duracloud/content.rb
+++ b/lib/duracloud/content.rb
@@ -1,5 +1,3 @@
-require "active_model"
-
 module Duracloud
   #
   # A piece of content in DuraCloud
@@ -12,6 +10,17 @@ module Duracloud
     COPY_SOURCE_HEADER = "x-dura-meta-copy-source"
     COPY_SOURCE_STORE_HEADER = "x-dura-meta-copy-source-store"
     MANIFEST_EXT = ".dura-manifest"
+
+    property :space_id, required: true
+    property :content_id, required: true
+    property :store_id
+    property :body
+    property :md5
+    property :content_type
+    property :size
+    property :modified
+
+    alias_method :id, :content_id
 
     # Does the content exist in DuraCloud?
     # @return [Boolean] whether the content exists.
@@ -54,11 +63,6 @@ module Duracloud
       find(**kwargs).delete
     end
 
-    attr_accessor :space_id, :content_id, :store_id,
-                  :body, :md5, :content_type, :size, :modified
-    alias_method :id, :content_id
-    validates_presence_of :space_id, :content_id
-
     # Return the space associated with this content.
     # @return [Duracloud::Space] the space.
     # @raise [Duracloud::NotFoundError] the space or store does not exist.
@@ -90,7 +94,7 @@ module Duracloud
     #   The current instance still represents the original content.
     # @raise [Duracloud::Error]
     def copy(**args)
-      dest = args.except(:force)
+      dest = args.reject { |k, v| k == :force }
       dest[:space_id]   ||= space_id
       dest[:store_id]   ||= store_id
       dest[:content_id] ||= content_id

--- a/lib/duracloud/content_manifest.rb
+++ b/lib/duracloud/content_manifest.rb
@@ -1,13 +1,12 @@
 require 'nokogiri'
-require 'active_model'
+require 'hashie'
 
 module Duracloud
-  class ContentManifest
-    include ActiveModel::Model
+  class ContentManifest < Hashie::Dash
 
-    validates_presence_of :space_id, :manifest_id
-
-    attr_accessor :space_id, :manifest_id, :store_id
+    property :space_id, required: true
+    property :manifest_id, required: true
+    property :store_id
 
     def self.find(**kwargs)
       new(**kwargs).tap do |manifest|

--- a/lib/duracloud/space.rb
+++ b/lib/duracloud/space.rb
@@ -7,7 +7,10 @@ module Duracloud
   #
   class Space < AbstractEntity
 
-    after_save :reset_acls
+    property :space_id, required: true
+    property :store_id
+
+    alias_method :id, :space_id
 
     # Max size of content item list for one request.
     #   This limit is imposed by Duracloud.
@@ -116,12 +119,6 @@ module Duracloud
         find(*args).manifest
       end
     end
-
-    attr_accessor :space_id, :store_id
-    alias_method :id, :space_id
-
-    after_save :reset_acls
-    before_delete :reset_acls
 
     # @param space_id [String] the space ID
     # @param store_id [String] the store ID (optional)
@@ -249,11 +246,13 @@ module Duracloud
     end
 
     def do_delete
+      reset_acls
       Client.delete_space(id, **query)
     end
 
     def do_save
       persisted? ? update : create
+      reset_acls
     end
 
     def query

--- a/lib/duracloud/storage_report.rb
+++ b/lib/duracloud/storage_report.rb
@@ -1,5 +1,4 @@
 require 'hashie'
-require 'active_support'
 
 module Duracloud
   class StorageReport < Hashie::Trash
@@ -15,17 +14,13 @@ module Duracloud
       @time ||= Time.at(timestamp / 1000.0).utc
     end
 
-    def human_size
-      ActiveSupport::NumberHelper.number_to_human_size(byte_count, prefix: :si)
-    end
-
     def to_s
       <<-EOS
 Date:       #{time}
 Space ID:   #{space_id || "(all)"}
 Store ID:   #{store_id}
 Objects:    #{object_count}
-Total size: #{human_size} (#{byte_count} bytes)
+Total size: #{byte_count} bytes
       EOS
     end
 

--- a/lib/duracloud/sync_validation.rb
+++ b/lib/duracloud/sync_validation.rb
@@ -1,11 +1,10 @@
-require 'active_model'
 require 'tempfile'
 require 'csv'
 require 'fileutils'
+require 'hashie'
 
 module Duracloud
-  class SyncValidation
-    include ActiveModel::Model
+  class SyncValidation < Hashie::Dash
 
     TWO_SPACES = '  '
     MD5_CSV_OPTS = { col_sep: TWO_SPACES }.freeze
@@ -15,7 +14,10 @@ module Duracloud
     CHANGED = "CHANGED"
     FOUND   = "FOUND"
 
-    attr_accessor :space_id, :content_dir, :store_id, :work_dir, :fast
+    property :space_id, required: true
+    property :content_dir, required: true
+    property :store_id
+    property :work_dir
 
     def self.call(*args)
       new(*args).call


### PR DESCRIPTION
Usage of ActiveModel::Model as an included module in several classes
has been functionally replaced by subclassing Hashie classes
(principally Hashie::Dash).