### PR TITLE
Hotfix 0.10.2

### DIFF
--- a/lib/duracloud/rest_methods.rb
+++ b/lib/duracloud/rest_methods.rb
@@ -130,8 +130,12 @@ module Duracloud
       execute(http_method, url, **options, &block)
     end
 
+    def escape_content_id(content_id)
+      content_id.gsub(/%/, "%25").gsub(/\#/, "%23")
+    end
+
     def durastore_content(http_method, space_id, content_id, **options, &block)
-      url = [ space_id, content_id.gsub(/%/, "%25") ].join("/")
+      url = [ space_id, escape_content_id(content_id) ].join("/")
       durastore(http_method, url, **options, &block)
     end
 

--- a/lib/duracloud/version.rb
+++ b/lib/duracloud/version.rb
@@ -1,3 +1,3 @@
 module Duracloud
-  VERSION = "0.10.1"
+  VERSION = "0.10.2"
 end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -9,77 +9,77 @@ module Duracloud
     end
 
     describe "get_spaces" do
-      specify {
+      it "works without a storeID" do
         stub = stub_request(:get, "https://example.com/durastore/spaces")
         subject.get_spaces
         expect(stub).to have_been_requested
-      }
-      specify {
+      end
+      it "works with a storeID" do
         stub = stub_request(:get, "https://example.com/durastore/spaces")
                            .with(query: {storeID: 1})
         subject.get_spaces(storeID: 1)
         expect(stub).to have_been_requested
-      }
+      end
     end
 
     describe "get_space" do
-      specify {
+      it "works without a storeID" do
         stub = stub_request(:get, "https://example.com/durastore/foo")
         subject.get_space("foo")
         expect(stub).to have_been_requested
-      }
-      specify {
+      end
+      it "works with a storeID" do
         stub = stub_request(:get, "https://example.com/durastore/foo")
                .with(query: {storeID: 1, prefix: "bar", maxResults: 50, marker: "item1"})
         subject.get_space("foo", storeID: 1, prefix: "bar", maxResults: 50, marker: "item1")
         expect(stub).to have_been_requested
-      }
+      end
     end
 
     describe "create_space" do
-      specify {
+      it "works without a storeID" do
         stub = stub_request(:put, "https://example.com/durastore/foo")
         subject.create_space("foo")
         expect(stub).to have_been_requested
-      }
-      specify {
+      end
+      it "works with a storeID" do
         stub = stub_request(:put, "https://example.com/durastore/foo")
                            .with(query: {storeID: 1})
         subject.create_space("foo", storeID: 1)
         expect(stub).to have_been_requested
-      }
+      end
     end
 
     describe "delete_space" do
-      specify {
+      it "works without a storeID" do
         stub = stub_request(:delete, "https://example.com/durastore/foo")
         subject.delete_space("foo")
         expect(stub).to have_been_requested
-      }
-      specify {
+      end
+      it "works with a storeID" do
         stub = stub_request(:delete, "https://example.com/durastore/foo")
                            .with(query: {storeID: 1})
         subject.delete_space("foo", storeID: 1)
         expect(stub).to have_been_requested
-      }
+      end
     end
 
     describe "get_space_acls" do
-      specify {
+      it "works without a storeID" do
         stub = stub_request(:head, "https://example.com/durastore/acl/foo")
         subject.get_space_acls("foo")
         expect(stub).to have_been_requested
-      }
-      specify {
+      end
+      it "works with a storeID" do
         stub = stub_request(:head, "https://example.com/durastore/acl/foo")
                .with(query: {storeID: 1})
         subject.get_space_acls("foo", storeID: 1)
         expect(stub).to have_been_requested
-      }
+      end
     end
 
     describe "set_space_acls" do
-      specify {
+      it "works without a storeID" do
         stub = stub_request(:post, "https://example.com/durastore/acl/foo")
                .with(headers: {'x-dura-meta-acl-user0'=>'WRITE',
                                'x-dura-meta-acl-user1'=>'WRITE',
@@ -89,8 +89,8 @@ module Duracloud
                                          'x-dura-meta-acl-user1'=>'WRITE',
                                          'x-dura-meta-acl-group-curators'=>'READ'})
         expect(stub).to have_been_requested
-      }
-      specify {
+      end
+      it "works with a storeID" do
         stub = stub_request(:post, "https://example.com/durastore/acl/foo")
                .with(headers: {'x-dura-meta-acl-user0'=>'WRITE',
                                'x-dura-meta-acl-user1'=>'WRITE',
@@ -102,63 +102,56 @@ module Duracloud
                                          'x-dura-meta-acl-user1'=>'WRITE',
                                          'x-dura-meta-acl-group-curators'=>'READ'})
         expect(stub).to have_been_requested
-      }
+      end
     end
 
     describe "get_content" do
-      specify {
+      it "works without a storeID" do
         stub = stub_request(:get, "https://example.com/durastore/foo/bar")
         subject.get_content("foo", "bar")
         expect(stub).to have_been_requested
-      }
-      it "escapes percent signs in the content id" do
-        stub = stub_request(:get, "https://example.com/durastore/foo/z/z/bar%252Fbaz")
-        subject.get_content("foo", "z/z/bar%2Fbaz")
-        expect(stub).to have_been_requested
       end
-      specify {
+      it "works with a storeID" do
         stub = stub_request(:get, "https://example.com/durastore/foo/bar")
                .with(query: {storeID: 1})
         subject.get_content("foo", "bar", storeID: 1)
         expect(stub).to have_been_requested
-      }
+      end
+      it "escapes percent and pound signs in the content id" do
+        stub = stub_request(:get, "https://example.com/durastore/foo/z/z/bar%252Fbaz%23bang")
+        subject.get_content("foo", "z/z/bar%2Fbaz#bang")
+        expect(stub).to have_been_requested
+      end
     end
 
     describe "get_content_properties" do
-      specify {
+      it "works without a storeID" do
         stub = stub_request(:head, "https://example.com/durastore/foo/bar")
         subject.get_content_properties("foo", "bar")
         expect(stub).to have_been_requested
-      }
-      it "escapes percent signs and spaces in the content id" do
-        stub = stub_request(:head, "https://example.com/durastore/foo/z/z/bar%252Fbaz%20spam%20eggs")
-        subject.get_content_properties("foo", "z/z/bar%2Fbaz spam eggs")
-        expect(stub).to have_been_requested
       end
-      specify {
+      it "works with a storeID" do
         stub = stub_request(:head, "https://example.com/durastore/foo/bar")
                .with(query: {storeID: 1})
         subject.get_content_properties("foo", "bar", storeID: 1)
         expect(stub).to have_been_requested
-      }
+      end
+      it "escapes percent and pound signs and spaces in the content id" do
+        stub = stub_request(:head, "https://example.com/durastore/foo/z/z/bar%252Fbaz%20spam%20eggs%23bang")
+        subject.get_content_properties("foo", "z/z/bar%2Fbaz spam eggs#bang")
+        expect(stub).to have_been_requested
+      end
     end
 
     describe "set_content_properties" do
-      specify {
+      it "works without a storeID" do
         stub = stub_request(:post, "https://example.com/durastore/foo/bar")
                .with(headers: {'x-dura-meta-owner'=>'testuser'})
         subject.set_content_properties("foo", "bar",
                                        headers: {'x-dura-meta-owner'=>'testuser'})
         expect(stub).to have_been_requested
-      }
-      it "escapes percent signs in the content id" do
-        stub = stub_request(:post, "https://example.com/durastore/foo/z/z/bar%252Fbaz")
-               .with(headers: {'x-dura-meta-owner'=>'testuser'})
-        subject.set_content_properties("foo", "z/z/bar%2Fbaz",
-                                       headers: {'x-dura-meta-owner'=>'testuser'})
-        expect(stub).to have_been_requested
       end
-      specify {
+      it "works with a storeID" do
         stub = stub_request(:post, "https://example.com/durastore/foo/bar")
                .with(headers: {'x-dura-meta-owner'=>'testuser'},
                      query: {storeID: 1})
@@ -166,11 +159,18 @@ module Duracloud
                                        headers: {'x-dura-meta-owner'=>'testuser'},
                                        storeID: 1)
         expect(stub).to have_been_requested
-      }
+      end
+      it "escapes percent and pound signs in the content id" do
+        stub = stub_request(:post, "https://example.com/durastore/foo/z/z/bar%252Fbaz%23%23bang")
+               .with(headers: {'x-dura-meta-owner'=>'testuser'})
+        subject.set_content_properties("foo", "z/z/bar%2Fbaz##bang",
+                                       headers: {'x-dura-meta-owner'=>'testuser'})
+        expect(stub).to have_been_requested
+      end
     end
 
     describe "store_content" do
-      specify {
+      it "works without a storeID" do
         stub = stub_request(:put, "https://example.com/durastore/foo/bar")
                .with(body: "File content",
                      headers: {
@@ -184,23 +184,8 @@ module Duracloud
                                 'Content-MD5'=>'8bb2564936980e92ceec8a5759ec34a8'
                               })
         expect(stub).to have_been_requested
-      }
-      it "escapes percent signs in the content id" do
-        stub = stub_request(:put, "https://example.com/durastore/foo/z/z/bar%252Fbaz")
-               .with(body: "File content",
-                     headers: {
-                       'Content-Type'=>'text/plain',
-                       'Content-MD5'=>'8bb2564936980e92ceec8a5759ec34a8'
-                     })
-        subject.store_content("foo", "z/z/bar%2Fbaz",
-                              body: "File content",
-                              headers: {
-                                'Content-Type'=>'text/plain',
-                                'Content-MD5'=>'8bb2564936980e92ceec8a5759ec34a8'
-                              })
-        expect(stub).to have_been_requested
       end
-      specify {
+      it "works with a storeID" do
         stub = stub_request(:put, "https://example.com/durastore/foo/bar")
                .with(body: "File content",
                      headers: {
@@ -216,26 +201,41 @@ module Duracloud
                               },
                               storeID: 1)
         expect(stub).to have_been_requested
-      }
+      end
+      it "escapes percent and pound signs in the content id" do
+        stub = stub_request(:put, "https://example.com/durastore/foo/z/z/bar%252Fbaz%23bang")
+               .with(body: "File content",
+                     headers: {
+                       'Content-Type'=>'text/plain',
+                       'Content-MD5'=>'8bb2564936980e92ceec8a5759ec34a8'
+                     })
+        subject.store_content("foo", "z/z/bar%2Fbaz#bang",
+                              body: "File content",
+                              headers: {
+                                'Content-Type'=>'text/plain',
+                                'Content-MD5'=>'8bb2564936980e92ceec8a5759ec34a8'
+                              })
+        expect(stub).to have_been_requested
+      end
     end
 
     describe "delete_content" do
-      specify {
+      it "works without a storeID" do
         stub = stub_request(:delete, "https://example.com/durastore/foo/bar")
         subject.delete_content("foo", "bar")
         expect(stub).to have_been_requested
-      }
-      it "escapes percent signs in the content id" do
-        stub = stub_request(:delete, "https://example.com/durastore/foo/z/z/bar%252Fbaz")
-        subject.delete_content("foo", "z/z/bar%2Fbaz")
-        expect(stub).to have_been_requested
       end
-      specify {
+      it "works with a storeID" do
         stub = stub_request(:delete, "https://example.com/durastore/foo/bar")
                .with(query: {storeID: 1})
         subject.delete_content("foo", "bar", storeID: 1)
         expect(stub).to have_been_requested
-      }
+      end
+      it "escapes percent and pound signs in the content id" do
+        stub = stub_request(:delete, "https://example.com/durastore/foo/z/z/bar%252Fbaz%23bang")
+        subject.delete_content("foo", "z/z/bar%2Fbaz#bang")
+        expect(stub).to have_been_requested
+      end
     end
 
     describe "copy_content" do
@@ -248,73 +248,73 @@ module Duracloud
     end
 
     describe "get_audit_log" do
-      specify {
+      it "works without a storeID" do
         stub = stub_request(:get, "https://example.com/durastore/audit/foo")
         subject.get_audit_log("foo")
         expect(stub).to have_been_requested
-      }
-      specify {
+      end
+      it "works with a storeID" do
         stub = stub_request(:get, "https://example.com/durastore/audit/foo")
                .with(query: {storeID: 1})
         subject.get_audit_log("foo", storeID: 1)
         expect(stub).to have_been_requested
-      }
+      end
     end
 
     describe "get_manifest" do
-      specify {
+      it "works without a storeID" do
         stub = stub_request(:get, "https://example.com/durastore/manifest/foo")
         subject.get_manifest("foo")
         expect(stub).to have_been_requested
-      }
-      specify {
+      end
+      it "works with a storeID" do
         stub = stub_request(:get, "https://example.com/durastore/manifest/foo")
                .with(query: {format: "BAGIT", storeID: 1})
         subject.get_manifest("foo", format: "BAGIT", storeID: 1)
         expect(stub).to have_been_requested
-      }
+      end
     end
 
     describe "generate_manifest" do
-      specify {
+      it "works without a storeID" do
         stub = stub_request(:post, "https://example.com/durastore/manifest/foo")
         subject.generate_manifest("foo")
         expect(stub).to have_been_requested
-      }
-      specify {
+      end
+      it "works with a storeID" do
         stub = stub_request(:post, "https://example.com/durastore/manifest/foo")
                .with(query: {format: "BAGIT", storeID: 1})
         subject.generate_manifest("foo", format: "BAGIT", storeID: 1)
         expect(stub).to have_been_requested
-      }
+      end
     end
 
     describe "get_bit_integrity_report" do
-      specify {
+      it "works without a storeID" do
         stub = stub_request(:get, "https://example.com/durastore/bit-integrity/foo")
         subject.get_bit_integrity_report("foo")
         expect(stub).to have_been_requested
-      }
-      specify {
+      end
+      it "works with a storeID" do
         stub = stub_request(:get, "https://example.com/durastore/bit-integrity/foo")
                .with(query: {storeID: 1})
         subject.get_bit_integrity_report("foo", storeID: 1)
         expect(stub).to have_been_requested
-      }
+      end
     end
 
     describe "get_bit_integrity_report_properties" do
-      specify {
+      it "works without a storeID" do
         stub = stub_request(:head, "https://example.com/durastore/bit-integrity/foo")
         subject.get_bit_integrity_report_properties("foo")
         expect(stub).to have_been_requested
-      }
-      specify {
+      end
+      it "works with a storeID" do
         stub = stub_request(:head, "https://example.com/durastore/bit-integrity/foo")
                .with(query: {storeID: 1})
         subject.get_bit_integrity_report_properties("foo", storeID: 1)
         expect(stub).to have_been_requested
-      }
+      end
     end
 
     describe "get_tasks" do


### PR DESCRIPTION
Adds escaping of pound sign in content ID so that is not transmitted
as a URL fragment.